### PR TITLE
add where fn to Join module

### DIFF
--- a/src/Garnet/Iteration.fs
+++ b/src/Garnet/Iteration.fs
@@ -563,6 +563,11 @@ module Join =
             fun (events : List<_>) ->
                 for e in events do
                     run e
+                    
+    let where pred action =
+        fun param values ->
+            if pred param values then
+                action param values
 
     let over c proc =
         proc c

--- a/tests/Garnet.Tests/IterationTests.fs
+++ b/tests/Garnet.Tests/IterationTests.fs
@@ -32,5 +32,22 @@ let tests =
                 |> Join.over c
             iter 0
             r.Count |> shouldEqual 16
+            
+        testCase "where" <| fun () ->
+            let c = ComponentStore(Eid.eidToComponentKey)
+            for i = 1 to 100 do
+                let e = c.Get(Eid i)
+                e.Add(i)
+                e.Add(Eid i)
+            c.Commit()
+            let r = List<_>()
+            let iterWhere =
+                fun param struct(a : int, b : Eid) ->
+                    r.Add((param, a, b))
+                |> Join.where (fun param struct(a : int, _ : Eid) -> a % 2 = 0)
+                |> Join.iter2
+                |> Join.over c
+            iterWhere 0
+            r.Count |> shouldEqual 50            
 
     ]


### PR DESCRIPTION
This adds the `where` comparison to the Join module per #10. The added test includes an example of its use.